### PR TITLE
adding exception on CalcPreco error from webservice

### DIFF
--- a/lib/correios.js
+++ b/lib/correios.js
@@ -66,7 +66,11 @@ Correios.prototype.calcPreco = function(args, callback) {
   // create the SOAP client
   soap.createClient(this.calcPrecoUrl, function(err, client) {
     client.CalcPreco(arg, function (err, result) {
-      callback(err, result.CalcPrecoResult.Servicos.cServico);
+      if (result && result.CalcPrecoResult && result.CalcPrecoResult.Servicos && result.CalcPrecoResult.Servicos.cServico) {
+        callback(err, result.CalcPrecoResult.Servicos.cServico);
+      } else {
+        callback(err, null);
+      }
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-correios",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Node.js module for the Brazilian mail service, Correios",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Caso haja problema na resposta do webservice não deveria dar crash no server ao acessar objeto nulo, mas deveria propagar o erro para o usuário.